### PR TITLE
fixed deprecation warning about bare variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,20 +12,20 @@
     question: "shared/accepted-oracle-license-v1-1"
     value: "true"
     vtype: "select"
-  with_items: oracle_java_versions
+  with_items: "{{ oracle_java_versions }}"
   tags: [configuration, oracle-java, oracle-java-install]
 
 - name: install
   apt:
     name: "oracle-java{{ item.version }}-installer"
     state: latest
-  with_items: oracle_java_versions
+  with_items: "{{ oracle_java_versions }}"
   tags: [configuration, oracle-java, oracle-java-install]
 
 - name: set environment variables
   apt:
     name: "oracle-java{{ item.version }}-set-default"
     state: latest
-  with_items: oracle_java_versions
+  with_items: "{{ oracle_java_versions }}"
   when: item.set_as_default is defined and item.set_as_default
   tags: [configuration, oracle-java, oracle-java-set-environment]


### PR DESCRIPTION
Hi,

I just fixed the deprecation warning created by ansible..

example error message:
==> controller: TASK [ansible-oracle-java : set environment variables] *************************
==> controller: task path: /vagrant/ansible/roles/ansible-oracle-java/tasks/main.yml:25
==> controller: [DEPRECATION WARNING]: Using bare variables is deprecated.
Update your
==> controller: playbooks so that the environment value uses the full variable syntax
==> controller: ('{{oracle_java_versions}}').
==> controller: This feature will be removed in a future release.
==> controller:  Deprecation warnings can be disabled by setting deprecation_warnings=False in
==> controller: ansible.cfg.

All the best,
andreas
